### PR TITLE
Requestor storage.

### DIFF
--- a/ongaku/abc/track.py
+++ b/ongaku/abc/track.py
@@ -52,7 +52,11 @@ class Track(abc.ABC):
 
     @property
     def user_data(self) -> typing.Mapping[str, typing.Any]:
-        """Additional track data."""
+        """Additional track data.
+
+        !!! warning
+            If you store a value of any type under the name `ongaku_requestor` it will be overridden.
+        """
         return self._user_data
 
     @property

--- a/ongaku/builders.py
+++ b/ongaku/builders.py
@@ -1309,12 +1309,18 @@ class EntityBuilder:
 
         _logger.log(TRACE_LEVEL, f"Decoding payload: {payload} into Track")
 
+        user_data: typing.MutableMapping[str, typing.Any] = (
+            data["userData"] if data.get("userData", None) else {}
+        )
+
+        requestor = user_data.pop("ongaku_requestor", None)
+
         return track.Track(
             data["encoded"],
             self.build_track_info(data["info"]),
             data["pluginInfo"],
-            data["userData"] if data.get("userData", None) else {},
-            None,
+            user_data,
+            hikari.Snowflake(requestor) if requestor else None,
         )
 
     def build_track_info(self, payload: types.PayloadMappingT) -> track_.TrackInfo:

--- a/ongaku/rest.py
+++ b/ongaku/rest.py
@@ -553,13 +553,18 @@ class RESTClient:
                     }
                 )
             else:
-                patch_data.update(
-                    {
-                        "track": {
-                            "encoded": track.encoded,
-                        }
-                    }
-                )
+                track_data: typing.MutableMapping[str, typing.Any] = {
+                    "encoded": track.encoded
+                }
+
+                user_data = dict(track.user_data)
+
+                if track.requestor:
+                    user_data.update({"ongaku_requestor": str(track.requestor)})
+
+                track_data.update({"userData": user_data})
+
+                patch_data.update({"track": track_data})
 
         if position != hikari.UNDEFINED:
             patch_data.update({"position": position})

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -480,6 +480,20 @@ class TestBuilderTrack:
         assert parsed_result.user_data == {}
         assert parsed_result.requestor is None
 
+    def test_track_with_requestor(self, builder: EntityBuilder):
+        payload = dict(payloads.TRACK_PAYLOAD)
+
+        payload["userData"] = {"ongaku_requestor": "1234"}
+        parsed_result = builder.build_track(payload)
+
+        assert parsed_result.encoded == "encoded"
+        assert parsed_result.info == builder.build_track_info(
+            payloads.TRACK_INFO_PAYLOAD
+        )
+        assert parsed_result.plugin_info == {}
+        assert parsed_result.user_data == {}
+        assert parsed_result.requestor == hikari.Snowflake(1234)
+
     def test_build_track_info(self, builder: EntityBuilder):
         parsed_result = builder.build_track_info(payloads.TRACK_INFO_PAYLOAD)
 

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -684,7 +684,9 @@ class TestRestPlayer:
             await rest.update_player(
                 "session_id",
                 Snowflake(1234567890),
-                track=mock.Mock(encoded="encoded"),
+                track=mock.Mock(
+                    encoded="encoded", user_data={}, requestor=Snowflake(1234)
+                ),
                 position=1,
                 end_time=2,
                 volume=3,
@@ -702,7 +704,10 @@ class TestRestPlayer:
                 dict,
                 headers={"Content-Type": "application/json"},
                 json={
-                    "track": {"encoded": "encoded"},
+                    "track": {
+                        "encoded": "encoded",
+                        "userData": {"ongaku_requestor": "1234"},
+                    },
                     "position": 1,
                     "endTime": 2,
                     "volume": 3,
@@ -739,7 +744,9 @@ class TestRestPlayer:
             await rest.update_player(
                 "session_id",
                 Snowflake(1234567890),
-                track=mock.Mock(encoded="encoded"),
+                track=mock.Mock(
+                    encoded="encoded", user_data={}, requestor=Snowflake(1234)
+                ),
                 position=1,
                 end_time=2,
                 volume=3,
@@ -757,7 +764,10 @@ class TestRestPlayer:
                 dict,
                 headers={"Content-Type": "application/json"},
                 json={
-                    "track": {"encoded": "encoded"},
+                    "track": {
+                        "encoded": "encoded",
+                        "userData": {"ongaku_requestor": "1234"},
+                    },
                     "position": 1,
                     "endTime": 2,
                     "volume": 3,


### PR DESCRIPTION
The requestor is now stored within the `userData` portion on lavalink, meaning if you set a user on a song `.play(track, requestor)` or `.add(track | playlist, requestor)` will make it so when you receive events, they will contain that requestor.