### PR TITLE
Add youtube endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,11 @@ async def message_event(
 
 ### Extensions
 
-Ongaku has two extension built-in:
+Ongaku has a few built-in extensions:
 
 - [`ext.checker`](https://ongaku.mplaty.com/ext/checker/) - For checking if a song is a URL, or just a query.
 - [`ext.injection`](https://ongaku.mplaty.com/ext/injection/) - For injecting player instances into commands.
+- [`ext.youtube`](https://ongaku.mplaty.com/ext/youtube/) - For setting or getting the token for your youtube config.
 
 ### Issues and support
 

--- a/docs/ext/youtube.md
+++ b/docs/ext/youtube.md
@@ -1,0 +1,8 @@
+---
+title: Youtube
+description: Additional endpoints, for youtube tokens.
+---
+
+# Youtube
+
+::: ongaku.ext.youtube

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
     - Creation: ext/creation.md
     - Checker: ext/checker.md
     - Injection: ext/injection.md
+    - Youtube: ext/youtube.md
   - Changelog: changelog.md
 
 

--- a/ongaku/ext/youtube/__init__.py
+++ b/ongaku/ext/youtube/__init__.py
@@ -1,0 +1,33 @@
+"""Youtube.
+
+Endpoints for the youtube source plugin.
+"""
+
+from __future__ import annotations
+
+from ongaku.ext.youtube.endpoints import fetch_youtube
+from ongaku.ext.youtube.endpoints import update_youtube
+
+__all__ = ("fetch_youtube", "update_youtube")
+
+# MIT License
+
+# Copyright (c) 2023-present MPlatypus
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/ongaku/ext/youtube/endpoints.py
+++ b/ongaku/ext/youtube/endpoints.py
@@ -13,6 +13,7 @@ async def fetch_youtube(session: Session, /) -> str | None:
     Get Youtube.
 
     Gets the current Youtube Refresh Token.
+    ![Lavalink](../assets/lavalink_logo.png){ .twemoji } [Reference](https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#get-youtube)
 
     Example
     -------

--- a/ongaku/ext/youtube/endpoints.py
+++ b/ongaku/ext/youtube/endpoints.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from ongaku.session import Session
+
+__all__ = ("fetch_youtube", "update_youtube")
+
+
+async def fetch_youtube(session: Session, /) -> str | None:
+    """
+    Get Youtube.
+
+    Gets the current Youtube Refresh Token.
+
+    Example
+    -------
+    ```py
+    token = await client.rest.fetch_youtube()
+
+    print(token)
+    ```
+
+    Parameters
+    ----------
+    session
+        If provided, the session to use for this request.
+
+    Raises
+    ------
+    NoSessionsError
+        Raised when there is no available sessions for this request to take place.
+    TimeoutError
+        Raised when the request takes too long to respond.
+    RestEmptyError
+        Raised when the request required a return type, but received nothing, or a 204 response.
+    RestStatusError
+        Raised when a 4XX or a 5XX status is received.
+    BuildError
+        Raised when the statistics could not be built.
+    RestRequestError
+        Raised when a 4XX or a 5XX status is received, and lavalink gives more information.
+    RestError
+        Raised when an unknown error is caught.
+
+    Returns
+    -------
+    str
+        The refresh token.
+    None
+        Returned when youtube is disabled.
+    """
+    response = await session.request(
+        "GET",
+        "/youtube",
+        str,
+    )
+
+    if response is None:
+        raise ValueError("Response is required for this request.")
+
+    return response
+
+
+async def update_youtube(
+    session: Session,
+    /,
+    *,
+    refresh_token: str | None = None,
+    skip_initialization: bool | None = None,
+    po_token: str | None = None,
+    visitor_data: str | None = None,
+) -> None:
+    """
+    Update Youtube.
+
+    Update youtube endpoints.
+    ![Lavalink](../assets/lavalink_logo.png){ .twemoji } [Reference](https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#post-youtube)
+
+    Example
+    -------
+    ```py
+    await client.rest.update_youtube(
+        refresh_token="acooltoken",
+        skip_initialization=True,
+        po_token="anothercooltoken",
+        visitor_data="visitordata",
+    )
+    ```
+
+    Parameters
+    ----------
+    refresh_token
+        The refresh token to use.
+    skip_initialization
+        Whether to skip initialization of OAuth.
+    po_token
+        The PO Token to use.
+    visitor_data
+        The visitor data to use.
+    session
+        If provided, the session to use for this request.
+
+    Raises
+    ------
+    ValueError
+        Raised when no values have been modified.
+    NoSessionsError
+        Raised when there is no available sessions for this request to take place.
+    TimeoutError
+        Raised when the request takes too long to respond.
+    RestStatusError
+        Raised when a 4XX or a 5XX status is received.
+    RestRequestError
+        Raised when a 4XX or a 5XX status is received, and lavalink gives more information.
+    RestError
+        Raised when an unknown error is caught.
+    """
+    if (
+        refresh_token is None
+        and skip_initialization is None
+        and po_token is None
+        and visitor_data is None
+    ):
+        raise ValueError("At least one value must be modified.")
+
+    json: typing.Mapping[str, typing.Any] = {}
+
+    if refresh_token:
+        json.update({"refreshToken": refresh_token})
+
+    if skip_initialization is not None:
+        json.update({"skipInitialization": skip_initialization})
+
+    if po_token:
+        json.update({"poToken": po_token})
+
+    if visitor_data:
+        json.update({"visitorData": visitor_data})
+
+    await session.request("POST", "/youtube", None, json=json)

--- a/tests/ext/youtube.py
+++ b/tests/ext/youtube.py
@@ -1,0 +1,78 @@
+import mock
+import pytest
+
+from ongaku import Client
+from ongaku import Session
+from ongaku.ext import youtube as yt
+from ongaku.rest import RESTClient
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube(ongaku_client: Client, ongaku_session: Session):
+    rest = RESTClient(ongaku_client)
+
+    with (
+        mock.patch.object(rest._client, "_session_handler"),
+        mock.patch.object(
+            rest._client.session_handler,
+            "fetch_session",
+            return_value=ongaku_session,
+        ) as patched_fetch_session,
+        mock.patch.object(
+            ongaku_session,
+            "request",
+            new_callable=mock.AsyncMock,
+            return_value="refresh_token",
+        ) as patched_request,
+    ):
+        assert await yt.fetch_youtube(ongaku_session) == "refresh_token"
+
+        patched_fetch_session.assert_called_once()
+
+        patched_request.assert_called_once_with(
+            "GET",
+            "/youtube",
+            str,
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_youtube(ongaku_client: Client, ongaku_session: Session):
+    rest = RESTClient(ongaku_client)
+
+    # Test with payload
+    with (
+        mock.patch.object(rest._client, "_session_handler"),
+        mock.patch.object(
+            rest._client.session_handler,
+            "fetch_session",
+            return_value=ongaku_session,
+        ) as patched_fetch_session,
+        mock.patch.object(
+            ongaku_session,
+            "request",
+            new_callable=mock.AsyncMock,
+            return_value=None,
+        ) as patched_request,
+    ):
+        await yt.update_youtube(
+            ongaku_session,
+            refresh_token="refresh_token",
+            skip_initialization=False,
+            po_token="po_token",
+            visitor_data="visitor_data",
+        )
+
+        patched_fetch_session.assert_called_once()
+
+        patched_request.assert_called_once_with(
+            "POST",
+            "/youtube",
+            None,
+            json={
+                "refreshToken": "refresh_token",
+                "skipInitialization": False,
+                "poToken": "po_token",
+                "visitorData": "visitor_data",
+            },
+        )


### PR DESCRIPTION
Add youtube endpoints as an extension.

Reference: https://github.com/lavalink-devs/youtube-source?tab=readme-ov-file#rest-routes-plugin-only
