### PR TITLE
Fixed single track looping issue.

### DIFF
--- a/ongaku/player.py
+++ b/ongaku/player.py
@@ -1036,6 +1036,40 @@ class Player:
 
         if len(self.queue) == 0:
             return
+        
+        if len(self.queue) == 1 and not self.loop:
+            new_event = events.QueueEmptyEvent.from_session(
+                self.session, self.guild_id, self.queue[0]
+            )
+
+            self.remove(0)
+
+            await self.app.event_manager.dispatch(new_event)
+
+            return
+        
+        if not self.loop:
+            self.remove(0)
+
+        _logger.log(
+            TRACE_LEVEL,
+            f"Auto-playing next track for channel: {self.channel_id} in guild: {self.guild_id}. Track title: {self.queue[0].info.title}",
+        )
+
+        await self.play()
+
+        await self.app.event_manager.dispatch(
+            events.QueueNextEvent.from_session(
+                self.session, self.guild_id, self._queue[0], event.track
+            )
+        )
+
+        _logger.log(
+            TRACE_LEVEL,
+            f"Auto-playing successfully completed for channel: {self.channel_id} in guild: {self.guild_id}",
+        )
+
+        return
 
         if len(self.queue) == 1:
             new_event = events.QueueEmptyEvent.from_session(

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -1017,7 +1017,7 @@ class TestPlayerTrackEndEvent:
 
             patched_dispatch.assert_called_once()
 
-            patched_play.assert_not_called()
+            patched_play.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_invalid_track_end_types(self, ongaku_session: Session):


### PR DESCRIPTION
There was an issue where if you had a single track in the queue, it would not loop, and do nothing. This should be fixed in both the tests and the library.